### PR TITLE
Improve admin dashboard and user management styling

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -64,7 +64,8 @@ class UserController extends Controller
             return back()->withErrors('Terjadi kesalahan saat menyimpan data.');
         }
 
-        return redirect()->route('admin.users.index');
+        // Redirect dengan pesan sukses agar muncul toaster (AI)
+        return redirect()->route('admin.users.index')->with('success', 'User berhasil dibuat');
     }
 
     /**
@@ -112,7 +113,8 @@ class UserController extends Controller
             return back()->withErrors('Terjadi kesalahan saat memperbarui data.');
         }
 
-        return redirect()->route('admin.users.index');
+        // Beri notifikasi sukses setelah update (AI)
+        return redirect()->route('admin.users.index')->with('success', 'User berhasil diperbarui');
     }
 
     /**
@@ -126,6 +128,7 @@ class UserController extends Controller
             Log::error('Gagal menghapus user: '.$e->getMessage()); // Penanganan error oleh AI
             return back()->withErrors('Terjadi kesalahan saat menghapus data.');
         }
-        return redirect()->route('admin.users.index');
+        // Informasi sukses setelah delete untuk toaster (AI)
+        return redirect()->route('admin.users.index')->with('success', 'User berhasil dihapus');
     }
 }

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -7,12 +7,20 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg p-6 text-center">
-                <x-application-logo class="mx-auto h-16 w-16 mb-4" /> <!-- Logo dashboard admin (AI) -->
-                <!-- Ringkasan singkat untuk admin -->
-                <p class="mb-2">Selamat datang, admin.</p>
-                <p class="mb-4">Total pengguna saat ini: {{ $users }}.</p>
-                <a href="{{ route('admin.users.index') }}" class="text-blue-600 underline">Kelola Pengguna</a>
+            <div class="grid gap-6 md:grid-cols-2">
+                <!-- Kartu jumlah pengguna (AI) -->
+                <div class="bg-white shadow sm:rounded-lg p-6">
+                    <h3 class="text-lg font-semibold">Total Pengguna</h3>
+                    <p class="mt-2 text-4xl font-bold">{{ $users }}</p>
+                </div>
+                <!-- Kartu navigasi ke pengelolaan pengguna (AI) -->
+                <div class="bg-white shadow sm:rounded-lg p-6 flex flex-col justify-between">
+                    <div>
+                        <h3 class="text-lg font-semibold">Kelola Pengguna</h3>
+                        <p class="text-gray-600">Tambah, ubah, atau hapus data pengguna.</p>
+                    </div>
+                    <a href="{{ route('admin.users.index') }}" class="mt-4 inline-block bg-blue-600 text-white px-4 py-2 rounded">Masuk</a>
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -6,9 +6,9 @@
     </x-slot>
 
     <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg p-6">
-                <!-- Form tambah user -->
+                <!-- Form tambah user dengan styling responsif (AI) -->
                 <form method="POST" action="{{ route('admin.users.store') }}">
                     @include('admin.users.form', ['submit' => 'Simpan'])
                 </form>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -6,9 +6,9 @@
     </x-slot>
 
     <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg p-6">
-                <!-- Form edit user -->
+                <!-- Form edit user dengan styling responsif (AI) -->
                 <form method="POST" action="{{ route('admin.users.update', $user) }}">
                     @method('PUT')
                     @include('admin.users.form', ['submit' => 'Update', 'user' => $user])

--- a/resources/views/admin/users/form.blade.php
+++ b/resources/views/admin/users/form.blade.php
@@ -1,6 +1,7 @@
 @csrf
 @php($user = $user ?? null)
-<div class="space-y-4">
+<!-- Grid form agar responsif pada berbagai ukuran layar (AI) -->
+<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
     <!-- Nama user -->
     <div>
         <x-label for="name" value="Nama" />

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -8,39 +8,41 @@
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg p-6">
-                <!-- Tombol untuk membuat user baru -->
-                <a href="{{ route('admin.users.create') }}" class="text-blue-600 underline">Tambah User</a>
+                <!-- Tombol untuk membuat user baru (AI) -->
+                <a href="{{ route('admin.users.create') }}" class="inline-block bg-blue-600 text-white px-4 py-2 rounded">Tambah User</a>
 
-                <!-- Tabel daftar pengguna -->
-                <table class="mt-4 w-full">
-                    <thead>
-                        <tr>
-                            <th class="text-left">Nama</th>
-                            <th class="text-left">Email</th>
-                            <th class="text-left">Peran</th>
-                            <th class="text-left">Langganan</th>
-                            <th>Aksi</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach ($users as $user)
-                            <tr class="border-t">
-                                <td>{{ $user->name }}</td>
-                                <td>{{ $user->email }}</td>
-                                <td>{{ $user->role }}</td>
-                                <td>{{ optional($user->subscription_expires_at)->format('d M Y') }}</td>
-                                <td class="space-x-2">
-                                    <a href="{{ route('admin.users.edit', $user) }}" class="text-green-600">Edit</a>
-                                    <form action="{{ route('admin.users.destroy', $user) }}" method="POST" class="inline">
-                                        @csrf
-                                        @method('DELETE')
-                                        <button class="text-red-600" onclick="return confirm('Hapus user?')">Hapus</button>
-                                    </form>
-                                </td>
+                <!-- Tabel daftar pengguna dengan desain responsif (AI) -->
+                <div class="mt-4 overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Nama</th>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Email</th>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Peran</th>
+                                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Langganan</th>
+                                <th class="px-4 py-2 text-sm font-medium text-gray-700">Aksi</th>
                             </tr>
-                        @endforeach
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200">
+                            @foreach ($users as $user)
+                                <tr class="hover:bg-gray-50">
+                                    <td class="px-4 py-2">{{ $user->name }}</td>
+                                    <td class="px-4 py-2">{{ $user->email }}</td>
+                                    <td class="px-4 py-2 capitalize">{{ $user->role }}</td>
+                                    <td class="px-4 py-2">{{ optional($user->subscription_expires_at)->format('d M Y') }}</td>
+                                    <td class="px-4 py-2 space-x-2">
+                                        <a href="{{ route('admin.users.edit', $user) }}" class="text-green-600">Edit</a>
+                                        <form action="{{ route('admin.users.destroy', $user) }}" method="POST" class="inline">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button class="text-red-600" onclick="return confirm('Hapus user?')">Hapus</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -41,7 +41,26 @@
         </div>
 
         @stack('modals')
-
         @livewireScripts
+
+        <!-- Komponen toast sederhana untuk menampilkan notifikasi (dibuat oleh AI) -->
+        @if (session('success'))
+            <div id="toast-success" class="fixed top-5 right-5 bg-green-500 text-white px-4 py-2 rounded shadow">
+                {{ session('success') }}
+            </div>
+            <script>
+                // Hilangkan toast setelah 3 detik (AI)
+                setTimeout(() => document.getElementById('toast-success')?.remove(), 3000);
+            </script>
+        @endif
+        @if ($errors->any())
+            <div id="toast-error" class="fixed top-5 right-5 bg-red-500 text-white px-4 py-2 rounded shadow">
+                {{ $errors->first() }}
+            </div>
+            <script>
+                // Toast error juga hilang otomatis (AI)
+                setTimeout(() => document.getElementById('toast-error')?.remove(), 3000);
+            </script>
+        @endif
     </body>
 </html>

--- a/resources/views/user/dashboard.blade.php
+++ b/resources/views/user/dashboard.blade.php
@@ -7,8 +7,8 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg p-6 text-center">
-                <x-application-logo class="mx-auto h-16 w-16 mb-4" /> <!-- Logo dashboard user (AI) -->
+            <!-- Kartu status langganan pengguna (AI) -->
+            <div class="bg-white shadow sm:rounded-lg p-6">
                 <h3 class="text-xl font-semibold">Halo, {{ auth()->user()->name }}</h3>
                 @if (auth()->user()->isSubscribed())
                     <p class="mt-2 text-green-600">Langganan aktif sampai {{ auth()->user()->subscription_expires_at->format('d M Y') }}.</p>


### PR DESCRIPTION
## Summary
- modernize admin and user dashboards with responsive cards
- restyle user management pages and forms for better usability
- add session-based toast notifications for CRUD actions

## Testing
- `npm run build`
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f21942888330848cac4e6974806f