### PR TITLE
feat: add subscription history and payment views

### DIFF
--- a/app/Http/Controllers/TopupController.php
+++ b/app/Http/Controllers/TopupController.php
@@ -75,4 +75,23 @@ class TopupController extends Controller
 
         return response()->json(['message' => 'ok']);
     }
+
+    /**
+     * Menampilkan riwayat topup pengguna.
+     * Komentar ini dihasilkan otomatis oleh AI.
+     */
+    public function history(Request $request)
+    {
+        $logs = $request->user()->topupLogs()->latest()->get();
+        return view('user.subscription-history', compact('logs'));
+    }
+
+    /**
+     * Menampilkan halaman pembayaran langganan.
+     * Komentar ini dihasilkan otomatis oleh AI.
+     */
+    public function showPay()
+    {
+        return view('user.subscription-pay');
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "autoprefixer": "^10.4.16",
                 "axios": "^1.11.0",
                 "concurrently": "^9.0.1",
+                "daisyui": "^5.1.6",
                 "laravel-vite-plugin": "^2.0.0",
                 "postcss": "^8.4.32",
                 "tailwindcss": "^3.4.0",
@@ -1708,6 +1709,16 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/daisyui": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.1.6.tgz",
+            "integrity": "sha512-KCzv25f+3lwWbfnPZZG9Xo0kSGO1NSysyIiS5AoCtDotIrvvArggHklCey1Fg6U2gZuqxsi2rptT1q3khoYCMw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/saadeghi/daisyui?sponsor=1"
             }
         },
         "node_modules/delayed-stream": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "autoprefixer": "^10.4.16",
         "axios": "^1.11.0",
         "concurrently": "^9.0.1",
+        "daisyui": "^5.1.6",
         "laravel-vite-plugin": "^2.0.0",
         "postcss": "^8.4.32",
         "tailwindcss": "^3.4.0",

--- a/resources/views/user/dashboard.blade.php
+++ b/resources/views/user/dashboard.blade.php
@@ -7,14 +7,20 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <!-- Kartu status langganan pengguna (AI) -->
-            <div class="bg-white shadow sm:rounded-lg p-6">
-                <h3 class="text-xl font-semibold">Halo, {{ auth()->user()->name }}</h3>
-                @if (auth()->user()->isSubscribed())
-                    <p class="mt-2 text-green-600">Langganan aktif sampai {{ auth()->user()->subscription_expires_at->format('d M Y') }}.</p>
-                @else
-                    <p class="mt-2 text-red-600">Langganan Anda telah habis. Biaya langganan Rp{{ number_format(config('subscription.price'),0,',','.') }} per 30 hari.</p>
-                @endif
+            <!-- Kartu status langganan pengguna dengan DaisyUI (AI) -->
+            <div class="card bg-base-100 shadow">
+                <div class="card-body">
+                    <h3 class="card-title">Halo, {{ auth()->user()->name }}</h3>
+                    @if (auth()->user()->isSubscribed())
+                        <p class="mt-2 text-green-600">Langganan aktif sampai {{ auth()->user()->subscription_expires_at->format('d M Y') }}.</p>
+                    @else
+                        <p class="mt-2 text-red-600">Langganan Anda telah habis. Biaya langganan Rp{{ number_format(config('subscription.price'),0,',','.') }} per 30 hari.</p>
+                    @endif
+                    <div class="card-actions mt-4">
+                        <a href="{{ route('subscription.history') }}" class="btn btn-outline">Riwayat</a>
+                        <a href="{{ route('subscription.pay') }}" class="btn btn-primary">Bayar Langganan</a>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/user/subscription-history.blade.php
+++ b/resources/views/user/subscription-history.blade.php
@@ -1,0 +1,42 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Riwayat Langganan') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <!-- Tabel riwayat langganan menggunakan komponen DaisyUI (AI) -->
+            <div class="overflow-x-auto">
+                <table class="table w-full">
+                    <thead>
+                        <tr>
+                            <th>Tanggal</th>
+                            <th>Jumlah</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($logs as $log)
+                            <tr>
+                                <td>{{ $log->created_at->format('d M Y') }}</td>
+                                <td>Rp{{ number_format($log->amount,0,',','.') }}</td>
+                                <td>
+                                    <span class="badge {{ $log->status === 'PAID' ? 'badge-success' : 'badge-warning' }}">
+                                        {{ $log->status }}
+                                    </span>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="text-center">Belum ada riwayat langganan</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/resources/views/user/subscription-pay.blade.php
+++ b/resources/views/user/subscription-pay.blade.php
@@ -1,0 +1,36 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Bayar Langganan') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <!-- Kartu pembayaran langganan menggunakan DaisyUI (AI) -->
+            <div class="card bg-base-100 shadow">
+                <div class="card-body">
+                    <p class="mb-4">Biaya langganan Rp{{ number_format(config('subscription.price'),0,',','.') }} per 30 hari.</p>
+                    <button id="pay-button" class="btn btn-primary w-full">Bayar Sekarang</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        document.getElementById('pay-button').addEventListener('click', async () => {
+            // Mengirim permintaan ke server untuk membuat invoice Xendit (komentar AI)
+            const response = await fetch('{{ route('subscription.invoice') }}', {
+                method: 'POST',
+                headers: {
+                    'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                    'Accept': 'application/json'
+                }
+            });
+            const data = await response.json();
+            // Mengarahkan pengguna ke halaman pembayaran Xendit (komentar AI)
+            window.location.href = data.invoice_url;
+        });
+    </script>
+</x-app-layout>
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Models\User;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
+use App\Http\Controllers\TopupController; // Controller topup untuk langganan (AI)
 
 Route::get('/', function () {
     return view('welcome');
@@ -23,6 +24,11 @@ Route::middleware([
         }
         return view('user.dashboard');
     })->name('dashboard');
+
+    // Halaman history dan pembayaran langganan (komentar AI)
+    Route::get('/subscription/history', [TopupController::class, 'history'])->name('subscription.history');
+    Route::get('/subscription/pay', [TopupController::class, 'showPay'])->name('subscription.pay');
+    Route::post('/subscription/invoice', [TopupController::class, 'createInvoice'])->name('subscription.invoice');
 
     // Grup route khusus admin dengan middleware 'admin' (komentar ini dibuat oleh AI)
     Route::middleware('admin')->prefix('admin')->name('admin.')->group(function () {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 import defaultTheme from 'tailwindcss/defaultTheme';
 import forms from '@tailwindcss/forms';
 import typography from '@tailwindcss/typography';
+import daisyui from 'daisyui'; // Plugin DaisyUI untuk komponen siap pakai (AI)
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -19,5 +20,6 @@ export default {
         },
     },
 
-    plugins: [forms, typography],
+    // Menambahkan DaisyUI untuk gaya antarmuka modern (komentar AI)
+    plugins: [forms, typography, daisyui],
 };


### PR DESCRIPTION
## Summary
- add DaisyUI plugin and styles
- implement subscription history and payment pages using Xendit
- update user dashboard with subscription actions

## Testing
- `npm run build`
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f5b90f588330bcc710aab3ad800a