### PR TITLE
feat: add daisyui theme toggle

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-theme="light"><!-- Data tema default (AI) -->
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -22,12 +22,12 @@
     <body class="font-sans antialiased">
         <x-banner />
 
-        <div class="min-h-screen bg-gray-100">
+        <div class="min-h-screen bg-base-200"><!-- Latar belakang dasar DaisyUI (AI) -->
             @livewire('navigation-menu')
 
             <!-- Page Heading -->
             @if (isset($header))
-                <header class="bg-white shadow">
+                <header class="bg-base-100 shadow"><!-- Bagian header dengan gaya DaisyUI (AI) -->
                     <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
                         {{ $header }}
                     </div>
@@ -42,6 +42,29 @@
 
         @stack('modals')
         @livewireScripts
+
+        <!-- Skrip untuk mengatur dan menyimpan tema gelap/terang (dibuat oleh AI) -->
+        <script>
+            const themeStorageKey = 'theme';
+            const root = document.documentElement;
+            const suns = () => document.querySelectorAll('.icon-sun');
+            const moons = () => document.querySelectorAll('.icon-moon');
+            const applyTheme = (t) => root.setAttribute('data-theme', t);
+            const updateIcons = () => {
+                const isLight = root.getAttribute('data-theme') === 'light';
+                suns().forEach(el => el.classList.toggle('hidden', !isLight));
+                moons().forEach(el => el.classList.toggle('hidden', isLight));
+            };
+            const savedTheme = localStorage.getItem(themeStorageKey) || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+            applyTheme(savedTheme);
+            updateIcons();
+            window.toggleTheme = () => {
+                const newTheme = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+                applyTheme(newTheme);
+                localStorage.setItem(themeStorageKey, newTheme);
+                updateIcons();
+            };
+        </script>
 
         <!-- Komponen toast sederhana untuk menampilkan notifikasi (dibuat oleh AI) -->
         @if (session('success'))

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -1,7 +1,7 @@
-<nav x-data="{ open: false }" class="bg-white border-b border-gray-100">
+<nav x-data="{ open: false }" class="navbar bg-base-100 border-b border-base-300"><!-- Navigasi utama dengan DaisyUI (AI) -->
     <!-- Primary Navigation Menu -->
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between h-16">
+    <div class="container mx-auto px-4"><!-- Kontainer responsif (AI) -->
+        <div class="flex justify-between items-center h-16">
             <div class="flex">
                 <!-- Logo -->
                 <div class="shrink-0 flex items-center">
@@ -18,7 +18,15 @@
                 </div>
             </div>
 
-            <div class="hidden sm:flex sm:items-center sm:ms-6">
+            <div class="hidden sm:flex sm:items-center sm:ms-6 gap-2">
+                <button onclick="toggleTheme()" class="btn btn-ghost btn-circle" title="Toggle theme"><!-- Tombol tema DaisyUI (AI) -->
+                    <svg xmlns="http://www.w3.org/2000/svg" class="icon-sun h-5 w-5 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v2m0 14v2m9-9h-2M5 12H3m15.364-6.364l-1.414 1.414M7.05 16.95l-1.414 1.414m0-11.314L7.05 7.05m11.314 11.314l-1.414-1.414M12 7a5 5 0 100 10 5 5 0 000-10z" />
+                    </svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" class="icon-moon h-5 w-5 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />
+                    </svg>
+                </button>
                 <!-- Teams Dropdown -->
                 @if (Laravel\Jetstream\Jetstream::hasTeamFeatures())
                     <div class="ms-3 relative">
@@ -124,8 +132,16 @@
                 </div>
             </div>
 
-            <!-- Hamburger -->
-            <div class="-me-2 flex items-center sm:hidden">
+            <!-- Tombol tema dan hamburger untuk mobile -->
+            <div class="-me-2 flex items-center sm:hidden gap-2">
+                <button onclick="toggleTheme()" class="btn btn-ghost btn-circle" title="Toggle theme"><!-- Tombol tema mobile (AI) -->
+                    <svg xmlns="http://www.w3.org/2000/svg" class="icon-sun h-5 w-5 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v2m0 14v2m9-9h-2M5 12H3m15.364-6.364l-1.414 1.414M7.05 16.95l-1.414 1.414m0-11.314L7.05 7.05m11.314 11.314l-1.414-1.414M12 7a5 5 0 100 10 5 5 0 000-10z" />
+                    </svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" class="icon-moon h-5 w-5 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />
+                    </svg>
+                </button>
                 <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
                     <svg class="size-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
                         <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,6 +20,11 @@ export default {
         },
     },
 
+    // Konfigurasi DaisyUI untuk tema terang dan gelap (AI)
+    daisyui: {
+        themes: ['light', 'dark'],
+    },
+
     // Menambahkan DaisyUI untuk gaya antarmuka modern (komentar AI)
     plugins: [forms, typography, daisyui],
 };


### PR DESCRIPTION
## Summary
- configure DaisyUI themes for light and dark modes
- implement theme toggle buttons on navigation including mobile
- add script to persist chosen theme

## Testing
- `npm run build`
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f74eac788330ac4785172d4f0ebc